### PR TITLE
[nrf noup] doc: remove Kconfig reference

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -117,7 +117,6 @@ Sections
 Indices and Tables
 ******************
 
-* :ref:`configuration_options`
 * :ref:`glossary`
 * :ref:`genindex`
 


### PR DESCRIPTION
NCS uses a separate docset for Kconfig reference, so remove references
to the configuration options page in Zephyr.