### PR TITLE
[nrf fromtree] logging: Add configurable logging thread delay

### DIFF
--- a/doc/reference/logging/index.rst
+++ b/doc/reference/logging/index.rst
@@ -156,6 +156,9 @@ threshold is used by the internal thread.
 :kconfig:`CONFIG_LOG_PROCESS_THREAD`: When enabled, logging thread is created
 which handles log processing.
 
+:kconfig:`CONFIG_LOG_PROCESS_THREAD_STARTUP_DELAY_MS`: Delay in milliseconds
+after which logging thread is started.
+
 :kconfig:`CONFIG_LOG_BUFFER_SIZE`: Number of bytes dedicated for the message pool.
 Single message capable of storing standard log with up to 3 arguments or hexdump
 message with 12 bytes of data take 32 bytes. In v2 it indicates buffer size

--- a/subsys/logging/Kconfig.processing
+++ b/subsys/logging/Kconfig.processing
@@ -67,6 +67,13 @@ config LOG_PROCESS_THREAD
 
 if LOG_PROCESS_THREAD
 
+config LOG_PROCESS_THREAD_STARTUP_DELAY_MS
+	int "Set log processing thread startup delay"
+	default 0
+	help
+	  Log processing thread starts after requested delay given in
+	  milliseconds. When started, thread process any buffered messages.
+
 config LOG_PROCESS_THREAD_SLEEP_MS
 	int "Set internal log processing thread sleep period"
 	default 1000

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -1419,7 +1419,10 @@ static int enable_logger(const struct device *arg)
 		k_thread_create(&logging_thread, logging_stack,
 				K_KERNEL_STACK_SIZEOF(logging_stack),
 				log_process_thread_func, NULL, NULL, NULL,
-				K_LOWEST_APPLICATION_THREAD_PRIO, 0, K_NO_WAIT);
+				K_LOWEST_APPLICATION_THREAD_PRIO, 0,
+				COND_CODE_1(CONFIG_LOG_PROCESS_THREAD,
+					K_MSEC(CONFIG_LOG_PROCESS_THREAD_STARTUP_DELAY_MS),
+					K_NO_WAIT));
 		k_thread_name_set(&logging_thread, "logging");
 	} else {
 		log_init();


### PR DESCRIPTION
This patch adds confiugurable delay when starting log processing
thread.

Jira: NCSDK-10822

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>
