### PR TITLE
[nrf fromtree] mgmt/mcumgr: Fix image erase returning

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -267,7 +267,6 @@ img_mgmt_erase(struct smp_streamer *ctxt)
 	struct image_version ver;
 	int rc;
 	zcbor_state_t *zsd = ctxt->reader->zs;
-	zcbor_state_t *zse = ctxt->writer->zs;
 	bool ok;
 	uint32_t slot = 1;
 	size_t decoded = 0;
@@ -307,12 +306,15 @@ img_mgmt_erase(struct smp_streamer *ctxt)
 		return rc;
 	}
 
-	if (IS_ENABLED(CONFIG_MCUMGR_SMP_LEGACY_RC_BEHAVIOUR) && zcbor_tstr_put_lit(zse, "rc") &&
-	    zcbor_int32_put(zse, 0)) {
-		return MGMT_ERR_EOK;
+	if (IS_ENABLED(CONFIG_MCUMGR_SMP_LEGACY_RC_BEHAVIOUR)) {
+		zcbor_state_t *zse = ctxt->writer->zs;
+
+		if (!zcbor_tstr_put_lit(zse, "rc") || !zcbor_int32_put(zse, 0)) {
+			return MGMT_ERR_EMSGSIZE;
+		}
 	}
 
-	return MGMT_ERR_EMSGSIZE;
+	return MGMT_ERR_EOK;
 }
 
 static int


### PR DESCRIPTION
... MGMT_ERR_EMSGSIZE

In case when CONFIG_MCUMGR_SMP_LEGACY_RC_BEHAVIOUR=n then the image erase command would incorrectly return MGMT_ERR_EMSGSIZE, even though no such error occurred.

(cherry picked from commit 00f1639e389e56f561e5c30d17c7567a3ab15f8b)
Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>